### PR TITLE
Fix missing SSH username on initial sync

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -97,7 +97,8 @@ const _buildUnisonConfigLine = function (
 
 export const buildUnisonConfig = function (config: IAccordanceConfig) {
     // Setup the local and remote roots
-    const remoteURL = `ssh://${config.remote.host}/${config.remote.root}`;
+    const username = config.remote.username || os.userInfo().username;
+    const remoteURL = `ssh://${username}@${config.remote.host}/${config.remote.root}`;
     const lines: string[] = [
         _buildUnisonConfigLine("root", config.local.root),
         _buildUnisonConfigLine("root", remoteURL),


### PR DESCRIPTION
Been playing around with this library as part of a Docker workflow, but ran into a problem where the remote username config isn't respected on the initial sync. Seems like it's not written properly to the `ssh://` URI in the Unison project file?

Update: Made a small tweak to have it fall back to the OS user when empty, as per the watch connection made in `main.ts`.