### PR TITLE
Add support for setting the remote SSH port

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ remote:
     username: crgwbr
     host: myserver.com
     root: ~/Projects/
+    port: 22
 
 # In the event of a conflict, which version should win? Must be set to either `local` or `remote`.
 prefer: local
@@ -162,8 +163,7 @@ This process will run until your end it with `ctrl+c`. While it's running it's d
 The following limitations currently apply:
 
 1. The local system must be able to SSH into the remote system. This is necessary for both FSEvent / INOTIFY monitoring and unison file syncing.
-    1. The SSH connection must be over port 22.
-    2. SSH Agent is the only supported authentication mechanism. The path to the SSH Agent socket must be set in the `SSH_AUTH_SOCK` environment variable and the private key must already be loaded into the agent (via `ssh-add`)
+    1. SSH Agent is the only supported authentication mechanism. The path to the SSH Agent socket must be set in the `SSH_AUTH_SOCK` environment variable and the private key must already be loaded into the agent (via `ssh-add`)
 
 These limitation are not design decisions, just limitations of the current implementation. They may be improved in future versions of Accordance.
 

--- a/config.example.yml
+++ b/config.example.yml
@@ -11,6 +11,7 @@ remote:
   username: crgwbr
   host: myserver.com
   root: ~/Projects/
+  port: 22
 
 # In the event of a conflict, which version should win? Must be set to either `local` or `remote`.
 prefer: local

--- a/src/main.ts
+++ b/src/main.ts
@@ -233,7 +233,7 @@ class AccordCLI {
         const sshAgentSock = process.env.SSH_AUTH_SOCK;
         const sshConfig: ConnectConfig = {
             host: config.remote.host,
-            port: 22,
+            port: config.remote.port || 22,
             username: config.remote.username || os.userInfo().username,
             agent: sshAgentSock,
         };

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -11,11 +11,16 @@ const AccordanceConfigBase = t.type({
     local: t.type({
         root: t.string,
     }),
-    remote: t.type({
-        username: t.string,
-        host: t.string,
-        root: t.string,
-    }),
+    remote: t.intersection([
+        t.type({
+            username: t.string,
+            host: t.string,
+            root: t.string,
+        }),
+        t.partial({
+            port: t.number,
+        }),
+    ]),
     prefer: t.union([t.literal("local"), t.literal("remote")]),
 });
 
@@ -98,7 +103,8 @@ const _buildUnisonConfigLine = function (
 export const buildUnisonConfig = function (config: IAccordanceConfig) {
     // Setup the local and remote roots
     const username = config.remote.username || os.userInfo().username;
-    const remoteURL = `ssh://${username}@${config.remote.host}/${config.remote.root}`;
+    const port = config.remote.port || 22;
+    const remoteURL = `ssh://${username}@${config.remote.host}:${port}/${config.remote.root}`;
     const lines: string[] = [
         _buildUnisonConfigLine("root", config.local.root),
         _buildUnisonConfigLine("root", remoteURL),

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -97,7 +97,8 @@ const _buildUnisonConfigLine = function (
 
 export const buildUnisonConfig = function (config: IAccordanceConfig) {
     // Setup the local and remote roots
-    const remoteURL = `ssh://${config.remote.host}/${config.remote.root}`;
+    const username = config.remote.username || os.userInfo().username;
+    const remoteURL = `ssh://${username}@${config.remote.host}/${config.remote.root}`;
     const lines: string[] = [
         _buildUnisonConfigLine("root", config.local.root),
         _buildUnisonConfigLine("root", remoteURL),


### PR DESCRIPTION
Adds support for setting the remote SSH port, with fallback to `22` when not set, so as to not break any existing configs.

Note that I've based this on PR #10 since they both affect the same line, and I'm not sure if I can tell Github to compare just the commit from this branch and not the other, since it only exists on my fork.